### PR TITLE
v4.0.0 with Major Changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: composer phpstan
 
       - name: Test
-        run: composer test -- --coverage-clover build/logs/clover.xml
+        run: composer test -- --testdox --coverage-clover build/logs/clover.xml
         env:
           PG_HOST: 127.0.0.1
           MY_HOST: 127.0.0.1

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-pdo": "*",
+        "illuminate/events": "^8.0 || ^9.0 || ^10.0",
         "illuminate/support": "^8.0 || ^9.0 || ^10.0",
         "illuminate/database": "^8.0 || ^9.0 || ^10.0",
         "illuminate/contracts": "^8.0 || ^9.0 || ^10.0"
@@ -46,6 +47,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
+        "laravel": {
+            "providers": [
+                "Mpyw\\LaravelDatabaseAdvisoryLock\\AdvisoryLockServiceProvider"
+            ]
+        },
         "phpstan": {
             "includes": [
                 "extension.neon"

--- a/src/AdvisoryLockServiceProvider.php
+++ b/src/AdvisoryLockServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelDatabaseAdvisoryLock;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * class AdvisoryLockServiceProvider
+ *
+ * Automatically registered through package discovery.
+ */
+final class AdvisoryLockServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(TransactionEventHub::class);
+    }
+
+    public function boot(TransactionEventHub $hub): void
+    {
+        TransactionEventHub::setResolver(fn () => $hub);
+    }
+}

--- a/src/AdvisoryLocks.php
+++ b/src/AdvisoryLocks.php
@@ -9,10 +9,18 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\QueryException;
 use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\LockerFactory as FactoryContract;
 
+/**
+ * trait AdvisoryLocks
+ *
+ * Designed to be mixed in with the Connection classes.
+ */
 trait AdvisoryLocks
 {
     public ?FactoryContract $advisoryLocker = null;
 
+    /**
+     * Create LockerFactory or return existing one.
+     */
     public function advisoryLocker(): FactoryContract
     {
         assert($this instanceof Connection);
@@ -21,6 +29,8 @@ trait AdvisoryLocks
     }
 
     /**
+     * Overrides the original implementation.
+     *
      * @param  string         $query
      * @param  array          $bindings
      * @throws QueryException
@@ -29,7 +39,7 @@ trait AdvisoryLocks
     {
         assert($this instanceof Connection);
 
-        // Don't try again if there are session-level locks
+        // Don't try again if there are session-level locks.
         if ($this->transactionLevel() > 0 || $this->advisoryLocker()->forSession()->hasAny()) {
             throw $e;
         }

--- a/src/Concerns/ReleasesWhenDestructed.php
+++ b/src/Concerns/ReleasesWhenDestructed.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Mpyw\LaravelDatabaseAdvisoryLock\Concerns;
 
-/**
- * @internal
- */
 trait ReleasesWhenDestructed
 {
     abstract public function release(): bool;

--- a/src/Concerns/SessionLocks.php
+++ b/src/Concerns/SessionLocks.php
@@ -14,17 +14,6 @@ trait SessionLocks
 {
     abstract public function lockOrFail(string $key, int $timeout = 0): SessionLock;
 
-    public function withLocking(string $key, callable $callback, int $timeout = 0): mixed
-    {
-        $lock = $this->lockOrFail($key, $timeout);
-
-        try {
-            return $callback();
-        } finally {
-            $lock->release();
-        }
-    }
-
     public function tryLock(string $key, int $timeout = 0): ?SessionLock
     {
         try {

--- a/src/Concerns/SessionLocks.php
+++ b/src/Concerns/SessionLocks.php
@@ -7,9 +7,6 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Concerns;
 use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\LockFailedException;
 use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\SessionLock;
 
-/**
- * @internal
- */
 trait SessionLocks
 {
     abstract public function lockOrFail(string $key, int $timeout = 0): SessionLock;

--- a/src/Concerns/TransactionalLocks.php
+++ b/src/Concerns/TransactionalLocks.php
@@ -6,9 +6,6 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Concerns;
 
 use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\LockFailedException;
 
-/**
- * @internal
- */
 trait TransactionalLocks
 {
     public function tryLock(string $key, int $timeout = 0): bool

--- a/src/Contracts/InvalidTransactionLevelException.php
+++ b/src/Contracts/InvalidTransactionLevelException.php
@@ -6,6 +6,11 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 
 use BadMethodCallException;
 
+/**
+ * class InvalidTransactionLevelException
+ *
+ * You can't use TransactionLocker outside of transaction.
+ */
 class InvalidTransactionLevelException extends BadMethodCallException
 {
 }

--- a/src/Contracts/LockFailedException.php
+++ b/src/Contracts/LockFailedException.php
@@ -7,6 +7,11 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 use Illuminate\Database\QueryException;
 use RuntimeException;
 
+/**
+ * class LockFailedException
+ *
+ * Lock acquisition has been failed.
+ */
 class LockFailedException extends QueryException
 {
     public function __construct(string $message, string $sql, array $bindings)

--- a/src/Contracts/LockerFactory.php
+++ b/src/Contracts/LockerFactory.php
@@ -4,9 +4,21 @@ declare(strict_types=1);
 
 namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 
+/**
+ * interface LockerFactory
+ *
+ * Entrypoint used from the mix-in AdvisoryLocks trait.
+ * Underlying locker instances are managed as singletons.
+ */
 interface LockerFactory
 {
+    /**
+     * Create a transaction-level locker or return existing one.
+     */
     public function forTransaction(): TransactionLocker;
 
+    /**
+     * Create a session-level locker or return existing one.
+     */
     public function forSession(): SessionLocker;
 }

--- a/src/Contracts/SessionLock.php
+++ b/src/Contracts/SessionLock.php
@@ -6,14 +6,27 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 
 use Illuminate\Database\QueryException;
 
+/**
+ * interface SessionLock
+ *
+ * Acquired through SessionLocker.
+ */
 interface SessionLock
 {
     /**
+     * Explicitly releases the lock.
+     * If successful, nothing happens the second time or later.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @throws QueryException
      */
     public function release(): bool;
 
     /**
+     * Implicitly releases the lock on the object destruction.
+     * If it has already been explicitly released by release(), nothing will happen.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @throws QueryException
      */
     public function __destruct();

--- a/src/Contracts/SessionLocker.php
+++ b/src/Contracts/SessionLocker.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\QueryException;
 
 interface SessionLocker
 {
     /**
      * @phpstan-template T
-     * @phpstan-param callable(): T $callback
+     * @phpstan-param callable(ConnectionInterface): T $callback
      * @phpstan-return T
      *
      * @psalm-template T
-     * @psalm-param callable(): T $callback
+     * @psalm-param callable(ConnectionInterface): T $callback
      * @psalm-return T
      *
      * @throws LockFailedException

--- a/src/Contracts/SessionLocker.php
+++ b/src/Contracts/SessionLocker.php
@@ -7,9 +7,18 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\QueryException;
 
+/**
+ * interface SessionLocker
+ *
+ * Session-level locker.
+ * Acquired locks must be explicitly released or connection must be disconnected.
+ */
 interface SessionLocker
 {
     /**
+     * Invoke $callback under the acquired lock then release it.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @phpstan-template T
      * @phpstan-param callable(ConnectionInterface): T $callback
      * @phpstan-return T
@@ -18,21 +27,32 @@ interface SessionLocker
      * @psalm-param callable(ConnectionInterface): T $callback
      * @psalm-return T
      *
+     * @param int $timeout Time to wait before acquiring a lock. This is NOT the expiry of the lock.
+     *
      * @throws LockFailedException
      * @throws QueryException
      */
     public function withLocking(string $key, callable $callback, int $timeout = 0): mixed;
 
     /**
+     * Attempts to acquire a lock or returns NULL if failed.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @throws QueryException
      */
     public function tryLock(string $key, int $timeout = 0): ?SessionLock;
 
     /**
+     * Attempts to acquire a lock or throw LockFailedException if failed.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @throws LockFailedException
      * @throws QueryException
      */
     public function lockOrFail(string $key, int $timeout = 0): SessionLock;
 
+    /**
+     * Indicates whether any session-level lock remains.
+     */
     public function hasAny(): bool;
 }

--- a/src/Contracts/TransactionLocker.php
+++ b/src/Contracts/TransactionLocker.php
@@ -6,14 +6,26 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 
 use Illuminate\Database\QueryException;
 
+/**
+ * interface TransactionLocker
+ *
+ * Transaction-level locker.
+ * Acquired locks are implicitly released on transaction commits/rollbacks.
+ */
 interface TransactionLocker
 {
     /**
+     * Attempts to acquire a lock or returns false if failed.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @throws QueryException
      */
     public function tryLock(string $key, int $timeout = 0): bool;
 
     /**
+     * Attempts to acquire a lock or throw LockFailedException if failed.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @throws LockFailedException
      * @throws QueryException
      */

--- a/src/Contracts/TransactionTerminationListener.php
+++ b/src/Contracts/TransactionTerminationListener.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
+
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionRolledBack;
+
+/**
+ * interface TransactionTerminationListener
+ *
+ * Some drivers can't release session-level locks immediately when an error occurs within a transaction.
+ * This listener is used for releasing after the transaction is terminated or rewinding to a savepoint.
+ */
+interface TransactionTerminationListener
+{
+    /**
+     * A listener function.
+     */
+    public function onTransactionTerminated(TransactionCommitted|TransactionRolledBack $event): void;
+}

--- a/src/Contracts/UnsupportedDriverException.php
+++ b/src/Contracts/UnsupportedDriverException.php
@@ -6,6 +6,11 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 
 use DomainException;
 
+/**
+ * class UnsupportedDriverException
+ *
+ * Requested operation is not supported on the driver.
+ */
 class UnsupportedDriverException extends DomainException
 {
 }

--- a/src/MySqlSessionLocker.php
+++ b/src/MySqlSessionLocker.php
@@ -30,16 +30,19 @@ final class MySqlSessionLocker implements SessionLocker
 
     public function lockOrFail(string $key, int $timeout = 0): SessionLock
     {
+        // When key strings exceed 64 bytes limit,
+        // it takes first 24 bytes from them and appends 40 bytes `sha1()` hashes.
         $sql = "SELECT GET_LOCK(CASE WHEN LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, {$timeout})";
         $bindings = array_fill(0, 4, $key);
 
         $result = (new Selector($this->connection))
-            ->selectBool($sql, $bindings, false);
+            ->selectBool($sql, $bindings);
 
         if (!$result) {
             throw new LockFailedException("Failed to acquire lock: {$key}", $sql, $bindings);
         }
 
+        // Register the lock when it succeeds.
         $lock = new MySqlSessionLock($this->connection, $this->locks, $key);
         $this->locks[$lock] = true;
 

--- a/src/MySqlSessionLocker.php
+++ b/src/MySqlSessionLocker.php
@@ -46,6 +46,17 @@ final class MySqlSessionLocker implements SessionLocker
         return $lock;
     }
 
+    public function withLocking(string $key, callable $callback, int $timeout = 0): mixed
+    {
+        $lock = $this->lockOrFail($key, $timeout);
+
+        try {
+            return $callback($this->connection);
+        } finally {
+            $lock->release();
+        }
+    }
+
     public function hasAny(): bool
     {
         return $this->locks->count() > 0;

--- a/src/PostgresSessionLock.php
+++ b/src/PostgresSessionLock.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace Mpyw\LaravelDatabaseAdvisoryLock;
 
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Database\PostgresConnection;
 use Mpyw\LaravelDatabaseAdvisoryLock\Concerns\ReleasesWhenDestructed;
 use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\SessionLock;
+use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\TransactionTerminationListener;
+use PDOException;
 use WeakMap;
 
-final class PostgresSessionLock implements SessionLock
+final class PostgresSessionLock implements SessionLock, TransactionTerminationListener
 {
     use ReleasesWhenDestructed;
 
     private bool $released = false;
+    private ?TransactionEventHub $hub;
 
     /**
      * @param WeakMap<SessionLock, bool> $locks
@@ -23,19 +28,43 @@ final class PostgresSessionLock implements SessionLock
         private WeakMap $locks,
         private string $key,
     ) {
+        $this->hub = TransactionEventHub::resolve();
+        $this->hub?->initializeWithDispatcher($this->connection->getEventDispatcher());
     }
 
     public function release(): bool
     {
         if (!$this->released) {
-            $this->released = (new Selector($this->connection))
-                ->selectBool('SELECT pg_advisory_unlock(hashtext(?))', [$this->key], false);
-
-            if ($this->released) {
-                $this->locks->offsetUnset($this);
+            try {
+                $this->released = (new Selector($this->connection))
+                    ->selectBool('SELECT pg_advisory_unlock(hashtext(?))', [$this->key]);
+            } catch (PDOException $e) {
+                // Postgres can't release session-level locks immediately
+                // when an error occurs within a transaction.
+                // Register onTransactionTerminated() for releasing
+                // after the transaction is terminated or rewinding to a savepoint.
+                self::causedByTransactionAbort($e)
+                    ? $this->hub?->registerOnceListener($this)
+                    : throw $e;
             }
+
+            // Clean up the lock when it succeeds.
+            $this->released && $this->locks->offsetUnset($this);
         }
 
         return $this->released;
+    }
+
+    /**
+     * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+     */
+    private static function causedByTransactionAbort(PDOException $e): bool
+    {
+        return $e->getCode() === '25P02';
+    }
+
+    public function onTransactionTerminated(TransactionCommitted|TransactionRolledBack $event): void
+    {
+        $this->release();
     }
 }

--- a/src/PostgresSessionLocker.php
+++ b/src/PostgresSessionLocker.php
@@ -50,6 +50,17 @@ final class PostgresSessionLocker implements SessionLocker
         return $lock;
     }
 
+    public function withLocking(string $key, callable $callback, int $timeout = 0): mixed
+    {
+        $lock = $this->lockOrFail($key, $timeout);
+
+        try {
+            return $callback($this->connection);
+        } finally {
+            $lock->release();
+        }
+    }
+
     public function hasAny(): bool
     {
         return $this->locks->count() > 0;

--- a/src/PostgresSessionLocker.php
+++ b/src/PostgresSessionLocker.php
@@ -27,6 +27,11 @@ final class PostgresSessionLocker implements SessionLocker
         $this->locks = new WeakMap();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * Use of this method is strongly discouraged in Postgres. Use withLocking() instead.
+     */
     public function lockOrFail(string $key, int $timeout = 0): SessionLock
     {
         if ($timeout !== 0) {
@@ -38,12 +43,13 @@ final class PostgresSessionLocker implements SessionLocker
         $sql = 'SELECT pg_try_advisory_lock(hashtext(?))';
 
         $result = (new Selector($this->connection))
-            ->selectBool($sql, [$key], false);
+            ->selectBool($sql, [$key]);
 
         if (!$result) {
             throw new LockFailedException("Failed to acquire lock: {$key}", $sql, [$key]);
         }
 
+        // Register the lock when it succeeds.
         $lock = new PostgresSessionLock($this->connection, $this->locks, $key);
         $this->locks[$lock] = true;
 
@@ -55,7 +61,12 @@ final class PostgresSessionLocker implements SessionLocker
         $lock = $this->lockOrFail($key, $timeout);
 
         try {
-            return $callback($this->connection);
+            // In Postgres, savepoints allow recovery from errors.
+            // This ensures release() on finally.
+            /** @noinspection PhpUnhandledExceptionInspection */
+            return $this->connection->transactionLevel() > 0
+                ? $this->connection->transaction(fn () => $callback($this->connection))
+                : $callback($this->connection);
         } finally {
             $lock->release();
         }

--- a/src/PostgresTransactionLocker.php
+++ b/src/PostgresTransactionLocker.php
@@ -35,7 +35,7 @@ final class PostgresTransactionLocker implements TransactionLocker
         $sql = 'SELECT pg_try_advisory_xact_lock(hashtext(?))';
 
         $result = (new Selector($this->connection))
-            ->selectBool($sql, [$key], false);
+            ->selectBool($sql, [$key]);
 
         if (!$result) {
             throw new LockFailedException("Failed to acquire lock: {$key}", $sql, [$key]);

--- a/src/Selector.php
+++ b/src/Selector.php
@@ -8,6 +8,10 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\QueryException;
 
 /**
+ * class Selector
+ *
+ * Helper utilities to retrieve results.
+ *
  * @internal
  */
 final class Selector
@@ -18,14 +22,19 @@ final class Selector
     }
 
     /**
+     * Run query to get a boolean from the result.
+     * Illegal values are regarded as false.
+     * QueryException may be thrown on connection-level errors.
+     *
      * @throws QueryException
      */
-    public function selectBool(string $sql, array $bindings, bool $useReadPdo = true): bool
+    public function selectBool(string $sql, array $bindings): bool
     {
+        // Always pass false to $useReadPdo
         return (bool)current(
             (array)$this
                 ->connection
-                ->selectOne($sql, $bindings, $useReadPdo),
+                ->selectOne($sql, $bindings, false),
         );
     }
 }

--- a/src/TransactionEventHub.php
+++ b/src/TransactionEventHub.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelDatabaseAdvisoryLock;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionRolledBack;
+use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\TransactionTerminationListener;
+use Throwable;
+use WeakMap;
+
+use function spl_object_hash;
+
+/**
+ * class TransactionEventHub
+ *
+ * Associate an event dispatcher on a connection with a listener of session-level locks.
+ * WeakMap prevents memory leaks.
+ */
+final class TransactionEventHub
+{
+    /**
+     * @var WeakMap<Dispatcher, array<string, TransactionTerminationListener>>
+     */
+    private WeakMap $dispatchersAndListeners;
+
+    /**
+     * @var null|callable(): self
+     */
+    private static $resolver;
+
+    /**
+     * Set a singleton instance resolver.
+     *
+     * @param null|callable(): self $resolver
+     */
+    public static function setResolver(?callable $resolver): void
+    {
+        self::$resolver = $resolver;
+    }
+
+    /**
+     * Create or retrieve a singleton instance through resolver.
+     */
+    public static function resolve(): ?self
+    {
+        return self::$resolver ? (self::$resolver)() : null;
+    }
+
+    public function __construct()
+    {
+        $this->dispatchersAndListeners = new WeakMap();
+    }
+
+    /**
+     * Register self::onTransactionTerminated() as a listener once per connection.
+     */
+    public function initializeWithDispatcher(Dispatcher $dispatcher): void
+    {
+        if (!isset($this->dispatchersAndListeners[$dispatcher])) {
+            $dispatcher->listen(
+                [TransactionCommitted::class, TransactionRolledBack::class],
+                [self::class, 'onTransactionTerminated'],
+            );
+        }
+
+        $this->dispatchersAndListeners[$dispatcher] ??= [];
+    }
+
+    /**
+     * Register underlying user listener per connection.
+     * Listeners registered here are invoked only once.
+     */
+    public function registerOnceListener(TransactionTerminationListener $listener): void
+    {
+        foreach ($this->dispatchersAndListeners as $dispatcher => $_) {
+            $this->dispatchersAndListeners[$dispatcher][spl_object_hash($listener)] = $listener;
+        }
+    }
+
+    /**
+     * Fire on events.
+     */
+    public function onTransactionTerminated(TransactionCommitted|TransactionRolledBack $event): void
+    {
+        /** @var array<string, array<string, TransactionTerminationListener>> $savedListenerGroups */
+        $savedListenerGroups = [];
+
+        // First, save all listeners.
+        foreach ($this->dispatchersAndListeners as $dispatcher => $listeners) {
+            foreach ($listeners as $listener) {
+                $savedListenerGroups[spl_object_hash($dispatcher)][spl_object_hash($listener)] = $listener;
+            }
+        }
+
+        // Next, remove listeners in advance.
+        foreach ($this->dispatchersAndListeners as $dispatcher => $_) {
+            $this->dispatchersAndListeners[$dispatcher] = [];
+        }
+
+        // Finally, run the saved listeners.
+        // It does not matter if new listeners are registered again during the execution.
+        foreach ($savedListenerGroups as $savedListeners) {
+            foreach ($savedListeners as $listener) {
+                try {
+                    $listener->onTransactionTerminated($event);
+                } catch (Throwable) {
+                }
+            }
+        }
+    }
+}

--- a/tests/ReconnectionToleranceTest.php
+++ b/tests/ReconnectionToleranceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mpyw\LaravelDatabaseAdvisoryLock\Tests;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Events\StatementPrepared;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
@@ -98,12 +99,12 @@ class ReconnectionToleranceTest extends TestCase
         DB::connection('mysql')
             ->advisoryLocker()
             ->forSession()
-            ->withLocking('foo', function (): void {
+            ->withLocking('foo', function (ConnectionInterface $conn): void {
                 $this->startListening();
 
                 try {
                     // MySQL doesn't accept empty locks, so this will trigger QueryException
-                    DB::connection('mysql')
+                    $conn
                         ->advisoryLocker()
                         ->forSession()
                         ->withLocking('', fn () => null);

--- a/tests/TableTestCase.php
+++ b/tests/TableTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelDatabaseAdvisoryLock\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+abstract class TableTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $schema = Schema::connection('pgsql');
+
+        $schema->dropIfExists('users');
+        $schema->create('users', function (Blueprint $table): void {
+            $table->unsignedBigInteger('id')->unique();
+        });
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mpyw\LaravelDatabaseAdvisoryLock\Tests;
 
+use Mpyw\LaravelDatabaseAdvisoryLock\AdvisoryLockServiceProvider;
 use Mpyw\LaravelDatabaseAdvisoryLock\ConnectionServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -11,7 +12,10 @@ abstract class TestCase extends BaseTestCase
 {
     protected function getPackageProviders($app): array
     {
-        return [ConnectionServiceProvider::class];
+        return [
+            AdvisoryLockServiceProvider::class,
+            ConnectionServiceProvider::class,
+        ];
     }
 
     protected function getEnvironmentSetUp($app): void

--- a/tests/TransactionErrorRecoveryTest.php
+++ b/tests/TransactionErrorRecoveryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelDatabaseAdvisoryLock\Tests;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class TransactionErrorRecoveryTest extends TableTestCase
+{
+    /**
+     * @throws Throwable
+     */
+    public function testWithoutTransactions(): void
+    {
+        $passed = false;
+
+        $conn = DB::connection('pgsql');
+        assert($conn instanceof Connection);
+        $conn->enableQueryLog();
+
+        $conn
+            ->advisoryLocker()
+            ->forSession()
+            ->withLocking('foo', function (ConnectionInterface $conn) use (&$passed): void {
+                $this->assertSame(0, $conn->transactionLevel());
+                $conn->insert('insert into users(id) values(1)');
+
+                try {
+                    // The following statement triggers an error
+                    $conn->insert('insert into users(id) values(1)');
+                } catch (QueryException) {
+                }
+                // The following statement is valid because there are no transactions
+                $conn->insert('insert into users(id) values(2)');
+                $passed = true;
+            });
+
+        $this->assertTrue($passed);
+        $this->assertSame([
+            'SELECT pg_try_advisory_lock(hashtext(?))',
+            'insert into users(id) values(1)',
+            'insert into users(id) values(2)',
+            'SELECT pg_advisory_unlock(hashtext(?))',
+        ], array_column($conn->getQueryLog(), 'query'));
+
+        $this->assertNotNull(
+            DB::connection('pgsql2')
+                ->advisoryLocker()
+                ->forSession()
+                ->tryLock('foo'),
+        );
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWithLockingRollbacksToSavepoint(): void
+    {
+        $passed = false;
+
+        $conn = DB::connection('pgsql');
+        assert($conn instanceof Connection);
+        $conn->enableQueryLog();
+
+        $conn->transaction(function (ConnectionInterface $conn) use (&$passed): void {
+            $this->assertSame(1, $conn->transactionLevel());
+            $conn->insert('insert into users(id) values(1)');
+
+            try {
+                $conn
+                    ->advisoryLocker()
+                    ->forSession()
+                    ->withLocking('foo', function (ConnectionInterface $conn): void {
+                        // The level is 2 because savepoint is automatically created
+                        $this->assertSame(2, $conn->transactionLevel());
+
+                        // The following statement triggers an error
+                        $conn->insert('insert into users(id) values(1)');
+                        $this->fail();
+                    });
+                // @phpstan-ignore-next-line
+                $this->fail();
+            } catch (QueryException) {
+            }
+            // The following statement is valid because it is rolled back to the savepoint
+            $this->assertSame(1, $conn->transactionLevel());
+            $conn->insert('insert into users(id) values(2)');
+            $passed = true;
+        });
+
+        $this->assertTrue($passed);
+        $this->assertSame([
+            'insert into users(id) values(1)',
+            'SELECT pg_try_advisory_lock(hashtext(?))',
+            'SELECT pg_advisory_unlock(hashtext(?))',
+            'insert into users(id) values(2)',
+        ], array_column($conn->getQueryLog(), 'query'));
+
+        $this->assertNotNull(
+            DB::connection('pgsql2')
+                ->advisoryLocker()
+                ->forSession()
+                ->tryLock('foo'),
+        );
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testDestructorReleasesLocksAfterTransactionTerminated(): void
+    {
+        $conn = DB::connection('pgsql');
+        assert($conn instanceof Connection);
+        $conn->enableQueryLog();
+
+        try {
+            $conn->transaction(function (ConnectionInterface $conn): void {
+                // lockOrFail() doesn't create any savepoints
+                $this->assertSame(1, $conn->transactionLevel());
+
+                /** @noinspection PhpUnusedLocalVariableInspection */
+                $lock = $conn->advisoryLocker()->forSession()->lockOrFail('foo');
+                $this->assertSame(1, $conn->transactionLevel());
+
+                $conn->insert('insert into users(id) values(1)');
+
+                try {
+                    // The following statement triggers an error
+                    $conn->insert('insert into users(id) values(1)');
+                } catch (QueryException) {
+                }
+                // The following statement is invalid [*]
+                $conn->insert('insert into users(id) values(2)');
+                $this->fail();
+            });
+            $this->fail();
+        } catch (QueryException $e) {
+            // Thrown from [*]
+            $this->assertSame(
+                $e->getMessage(),
+                'SQLSTATE[25P02]: In failed sql transaction: 7 ERROR:  '
+                . 'current transaction is aborted, commands ignored until end of transaction block '
+                . '(SQL: insert into users(id) values(2))',
+            );
+        }
+
+        $this->assertSame([
+            'SELECT pg_try_advisory_lock(hashtext(?))',
+            'insert into users(id) values(1)',
+            'SELECT pg_advisory_unlock(hashtext(?))',
+        ], array_column($conn->getQueryLog(), 'query'));
+
+        $this->assertNotNull(
+            DB::connection('pgsql2')
+                ->advisoryLocker()
+                ->forSession()
+                ->tryLock('foo'),
+        );
+    }
+}

--- a/tests/TransactionErrorRefreshDatabaseRecoveryTest.php
+++ b/tests/TransactionErrorRefreshDatabaseRecoveryTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelDatabaseAdvisoryLock\Tests;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class TransactionErrorRefreshDatabaseRecoveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public array $connectionsToTransact = ['pgsql', 'pgsql2'];
+
+    /**
+     * @throws Throwable
+     */
+    public function testImplicitTransactionRollbacksToSavepoint(): void
+    {
+        $conn = DB::connection('pgsql');
+        assert($conn instanceof Connection);
+        $conn->enableQueryLog();
+
+        try {
+            $conn
+                ->advisoryLocker()
+                ->forSession()
+                ->withLocking('foo', function (ConnectionInterface $conn): void {
+                    // RefreshDatabase affects to the transaction level
+                    $this->assertSame(2, $conn->transactionLevel());
+                    $conn->insert('insert into users(id) values(1)');
+
+                    try {
+                        // The following statement triggers an error
+                        $conn->insert('insert into users(id) values(1)');
+                    } catch (QueryException) {
+                    }
+                    // The following statement is invalid [*]
+                    $conn->insert('insert into users(id) values(2)');
+                });
+        } catch (QueryException $e) {
+            // Thrown from [*]
+            $this->assertSame(
+                $e->getMessage(),
+                'SQLSTATE[25P02]: In failed sql transaction: 7 ERROR:  '
+                . 'current transaction is aborted, commands ignored until end of transaction block '
+                . '(SQL: insert into users(id) values(2))',
+            );
+        }
+
+        $this->assertSame([
+            'SELECT pg_try_advisory_lock(hashtext(?))',
+            'insert into users(id) values(1)',
+            'SELECT pg_advisory_unlock(hashtext(?))',
+        ], array_column($conn->getQueryLog(), 'query'));
+
+        $this->assertNotNull(
+            DB::connection('pgsql2')
+                ->advisoryLocker()
+                ->forSession()
+                ->tryLock('foo'),
+        );
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWithLockingRollbacksToSavepoint(): void
+    {
+        $passed = false;
+
+        $conn = DB::connection('pgsql');
+        assert($conn instanceof Connection);
+        $conn->enableQueryLog();
+
+        $conn->transaction(function (ConnectionInterface $conn) use (&$passed): void {
+            // RefreshDatabase affects to the transaction level
+            $this->assertSame(2, $conn->transactionLevel());
+            $conn->insert('insert into users(id) values(1)');
+
+            try {
+                $conn
+                    ->advisoryLocker()
+                    ->forSession()
+                    ->withLocking('foo', function (ConnectionInterface $conn): void {
+                        // The level is 3 because savepoint is automatically created
+                        $this->assertSame(3, $conn->transactionLevel());
+
+                        // The following statement triggers an error
+                        $conn->insert('insert into users(id) values(1)');
+                        $this->fail();
+                    });
+                // @phpstan-ignore-next-line
+                $this->fail();
+            } catch (QueryException) {
+            }
+            // The following statement is valid because it is rolled back to the savepoint
+            $this->assertSame(2, $conn->transactionLevel());
+            $conn->insert('insert into users(id) values(2)');
+            $passed = true;
+        });
+
+        $this->assertTrue($passed);
+        $this->assertSame([
+            'insert into users(id) values(1)',
+            'SELECT pg_try_advisory_lock(hashtext(?))',
+            'SELECT pg_advisory_unlock(hashtext(?))',
+            'insert into users(id) values(2)',
+        ], array_column($conn->getQueryLog(), 'query'));
+
+        $this->assertNotNull(
+            DB::connection('pgsql2')
+                ->advisoryLocker()
+                ->forSession()
+                ->tryLock('foo'),
+        );
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testDestructorReleasesLocksAfterRollingBackToSavepoint(): void
+    {
+        $conn = DB::connection('pgsql');
+        assert($conn instanceof Connection);
+        $conn->enableQueryLog();
+
+        try {
+            $conn->transaction(function (ConnectionInterface $conn): void {
+                // RefreshDatabase affects to the transaction level
+                $this->assertSame(2, $conn->transactionLevel());
+
+                // lockOrFail() doesn't create any savepoints
+                /** @noinspection PhpUnusedLocalVariableInspection */
+                $lock = $conn->advisoryLocker()->forSession()->lockOrFail('foo');
+                $this->assertSame(2, $conn->transactionLevel());
+
+                $conn->insert('insert into users(id) values(1)');
+
+                try {
+                    // The following statement triggers an error
+                    $conn->insert('insert into users(id) values(1)');
+                } catch (QueryException) {
+                }
+                // The following statement is invalid [*]
+                $conn->insert('insert into users(id) values(2)');
+                $this->fail();
+            });
+            $this->fail();
+        } catch (QueryException $e) {
+            // Thrown from [*]
+            $this->assertSame(
+                $e->getMessage(),
+                'SQLSTATE[25P02]: In failed sql transaction: 7 ERROR:  '
+                . 'current transaction is aborted, commands ignored until end of transaction block '
+                . '(SQL: insert into users(id) values(2))',
+            );
+        }
+
+        $this->assertSame([
+            'SELECT pg_try_advisory_lock(hashtext(?))',
+            'insert into users(id) values(1)',
+            'SELECT pg_advisory_unlock(hashtext(?))',
+        ], array_column($conn->getQueryLog(), 'query'));
+
+        $this->assertNotNull(
+            DB::connection('pgsql2')
+                ->advisoryLocker()
+                ->forSession()
+                ->tryLock('foo'),
+        );
+    }
+}


### PR DESCRIPTION
# What's the matter?

Up to version 3.x, the Postgres driver had a fatal problem. When a session-level lock was acquired in a transaction, it was not always possible to release the lock during the `finally` blocks; **once Postgres encountered an error in a transaction, it would kill all continuing operations with an error.**

Two approaches were adopted to solve this problem:

### Monitoring for commit/rollback events (including rollbacks to savepoints)

Even if the lock release process fails, it can be recovered by performing commit/rollback operations. When the event is detected, we will retry the lock release process.

### Issue savepoints on `withLocking()` calls

If a transaction has already been opened, a savepoint is created immediately after lock acquisition so that the lock can be released on the fly after recovering from an error that occurred within the callback function.

# Changes

- `AdvisoryLockServiceProvider` has been added; which is automatically discovered.
- `withLocking()` takes `ConnectionInterface` as a first argument.