### PR TITLE
v4.1.0 with New Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ Advisory Locking Features of Postgres/MySQL on Laravel
 
 ## Requirements
 
-| Package | Version                             | Mandatory |
-|:---|:------------------------------------|:---:|
-| PHP | <code>^8.0.2</code>                  | ✅ |
-| Laravel | <code>^8.0 &#124;&#124; ^9.0 &#124;&#124; ^10.0</code> | ✅ |
-| PHPStan | <code>&gt;=1.1</code>               | |
+| Package | Version                                                | Mandatory |
+|:--------|:-------------------------------------------------------|:---------:|
+| PHP     | <code>^8.0.2</code>                                    |     ✅     |
+| Laravel | <code>^8.0 &#124;&#124; ^9.0 &#124;&#124; ^10.0</code> |     ✅     |
+| PHPStan | <code>&gt;=1.1</code>                                  |           |
 
 ## Installing
 
 ```
-composer require mpyw/laravel-database-advisory-lock:^4.0
+composer require mpyw/laravel-database-advisory-lock:^4.1
 ```
 
 ## Basic usage

--- a/src/Contracts/LockFailedException.php
+++ b/src/Contracts/LockFailedException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mpyw\LaravelDatabaseAdvisoryLock\Contracts;
 
 use Illuminate\Database\QueryException;
+use ReflectionMethod;
 use RuntimeException;
 
 /**
@@ -14,8 +15,17 @@ use RuntimeException;
  */
 class LockFailedException extends QueryException
 {
-    public function __construct(string $message, string $sql, array $bindings)
+    public function __construct(string $connectionName, string $message, string $sql, array $bindings)
     {
-        parent::__construct($sql, $bindings, new RuntimeException($message));
+        $previous = new RuntimeException($message);
+
+        // Laravel 10 newly introduces $connectionName parameter
+        // https://github.com/laravel/framework/pull/43190
+        $args = (new ReflectionMethod(parent::class, __FUNCTION__))->getNumberOfParameters() > 3
+            ? [$connectionName, $sql, $bindings, $previous]
+            : [$sql, $bindings, $previous];
+
+        // @phpstan-ignore-next-line
+        parent::__construct(...$args);
     }
 }

--- a/src/MySqlSessionLock.php
+++ b/src/MySqlSessionLock.php
@@ -30,9 +30,9 @@ final class MySqlSessionLock implements SessionLock
     public function release(): bool
     {
         if (!$this->released) {
-            // When key strings exceed 64 bytes limit,
-            // it takes first 24 bytes from them and appends 40 bytes `sha1()` hashes.
-            $sql = 'SELECT RELEASE_LOCK(CASE WHEN LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END)';
+            // When key strings exceed 64 chars limit,
+            // it takes first 24 chars from them and appends 40 chars `sha1()` hashes.
+            $sql = 'SELECT RELEASE_LOCK(CASE WHEN CHAR_LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END)';
 
             $this->released = (new Selector($this->connection))
                 ->selectBool($sql, array_fill(0, 4, $this->key));

--- a/src/MySqlSessionLocker.php
+++ b/src/MySqlSessionLocker.php
@@ -39,7 +39,12 @@ final class MySqlSessionLocker implements SessionLocker
             ->selectBool($sql, $bindings);
 
         if (!$result) {
-            throw new LockFailedException("Failed to acquire lock: {$key}", $sql, $bindings);
+            throw new LockFailedException(
+                (string)$this->connection->getName(),
+                "Failed to acquire lock: {$key}",
+                $sql,
+                $bindings,
+            );
         }
 
         // Register the lock when it succeeds.

--- a/src/MySqlSessionLocker.php
+++ b/src/MySqlSessionLocker.php
@@ -30,9 +30,9 @@ final class MySqlSessionLocker implements SessionLocker
 
     public function lockOrFail(string $key, int $timeout = 0): SessionLock
     {
-        // When key strings exceed 64 bytes limit,
-        // it takes first 24 bytes from them and appends 40 bytes `sha1()` hashes.
-        $sql = "SELECT GET_LOCK(CASE WHEN LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, {$timeout})";
+        // When key strings exceed 64 chars limit,
+        // it takes first 24 chars from them and appends 40 chars `sha1()` hashes.
+        $sql = "SELECT GET_LOCK(CASE WHEN CHAR_LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, {$timeout})";
         $bindings = array_fill(0, 4, $key);
 
         $result = (new Selector($this->connection))

--- a/src/PostgresSessionLocker.php
+++ b/src/PostgresSessionLocker.php
@@ -45,7 +45,12 @@ final class PostgresSessionLocker implements SessionLocker
             ->selectBool($sql, [$key]);
 
         if (!$result) {
-            throw new LockFailedException("Failed to acquire lock: {$key}", $sql, [$key]);
+            throw new LockFailedException(
+                (string)$this->connection->getName(),
+                "Failed to acquire lock: {$key}",
+                $sql,
+                [$key],
+            );
         }
 
         // Register the lock when it succeeds.

--- a/src/PostgresSessionLocker.php
+++ b/src/PostgresSessionLocker.php
@@ -34,13 +34,12 @@ final class PostgresSessionLocker implements SessionLocker
      */
     public function lockOrFail(string $key, int $timeout = 0): SessionLock
     {
-        if ($timeout !== 0) {
-            // @codeCoverageIgnoreStart
-            throw new UnsupportedDriverException('Timeout feature is not supported');
-            // @codeCoverageIgnoreEnd
-        }
-
-        $sql = 'SELECT pg_try_advisory_lock(hashtext(?))';
+        // Negative timeout means infinite wait
+        $sql = match ($timeout <=> 0) {
+            -1 => "SELECT pg_advisory_lock(hashtext(?))::text = ''",
+            0 => 'SELECT pg_try_advisory_lock(hashtext(?))',
+            1 => throw new UnsupportedDriverException('Positive timeout is not supported'),
+        };
 
         $result = (new Selector($this->connection))
             ->selectBool($sql, [$key]);

--- a/src/PostgresTransactionLocker.php
+++ b/src/PostgresTransactionLocker.php
@@ -37,7 +37,12 @@ final class PostgresTransactionLocker implements TransactionLocker
             ->selectBool($sql, [$key]);
 
         if (!$result) {
-            throw new LockFailedException("Failed to acquire lock: {$key}", $sql, [$key]);
+            throw new LockFailedException(
+                (string)$this->connection->getName(),
+                "Failed to acquire lock: {$key}",
+                $sql,
+                [$key],
+            );
         }
     }
 }

--- a/tests/AcquiresLockInSeparateProcesses.php
+++ b/tests/AcquiresLockInSeparateProcesses.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mpyw\LaravelDatabaseAdvisoryLock\Tests;
+
+use Symfony\Component\Process\Process;
+
+trait AcquiresLockInSeparateProcesses
+{
+    private static function lockMysqlAsync(string $key, int $sleep): Process
+    {
+        $host = config('database.connections.mysql.host');
+        assert(is_string($host));
+
+        // == is intentionally used instead of ===.
+        // up to PHP 8.0, emulation mode on MySQL affects whether the return type is stringified or not.
+        $proc = new Process([PHP_BINARY, '-r',
+            <<<EOD
+            \$pdo = new PDO('mysql:host={$host};dbname=testing', 'testing', 'testing');
+            \$result = \$pdo->query("SELECT GET_LOCK('{$key}', 0)")->fetchColumn();
+            sleep({$sleep});
+            exit(\$result == 1 ? 0 : 1);
+            EOD,
+        ]);
+        $proc->start();
+
+        return $proc;
+    }
+
+    private static function lockPostgresAsync(string $key, int $sleep): Process
+    {
+        $host = config('database.connections.pgsql.host');
+        assert(is_string($host));
+
+        $proc = new Process([PHP_BINARY, '-r',
+            <<<EOD
+            \$pdo = new PDO('pgsql:host={$host};dbname=testing', 'testing', 'testing');
+            \$result = \$pdo->query("SELECT pg_try_advisory_lock(hashtext('{$key}'))")->fetchColumn();
+            sleep({$sleep});
+            exit(\$result ? 0 : 1);
+            EOD,
+        ]);
+        $proc->start();
+
+        return $proc;
+    }
+}

--- a/tests/ReconnectionToleranceTest.php
+++ b/tests/ReconnectionToleranceTest.php
@@ -89,8 +89,8 @@ class ReconnectionToleranceTest extends TestCase
 
         // Retries
         $this->assertSame([
-            'SELECT GET_LOCK(CASE WHEN LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, 0)',
-            'SELECT GET_LOCK(CASE WHEN LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, 0)',
+            'SELECT GET_LOCK(CASE WHEN CHAR_LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, 0)',
+            'SELECT GET_LOCK(CASE WHEN CHAR_LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, 0)',
         ], $this->queries);
     }
 
@@ -115,7 +115,7 @@ class ReconnectionToleranceTest extends TestCase
 
         // No retries
         $this->assertSame([
-            'SELECT GET_LOCK(CASE WHEN LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, 0)',
+            'SELECT GET_LOCK(CASE WHEN CHAR_LENGTH(?) > 64 THEN CONCAT(SUBSTR(?, 1, 24), SHA1(?)) ELSE ? END, 0)',
         ], $this->queries);
     }
 }

--- a/tests/SessionLockerTest.php
+++ b/tests/SessionLockerTest.php
@@ -7,10 +7,13 @@ namespace Mpyw\LaravelDatabaseAdvisoryLock\Tests;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\DB;
 use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\LockFailedException;
+use Mpyw\LaravelDatabaseAdvisoryLock\Contracts\UnsupportedDriverException;
 use Mpyw\LaravelDatabaseAdvisoryLock\Selector;
 
 class SessionLockerTest extends TestCase
 {
+    use AcquiresLockInSeparateProcesses;
+
     public function connections(): array
     {
         return ['postgres' => ['pgsql'], 'mysql' => ['mysql']];
@@ -147,5 +150,102 @@ class SessionLockerTest extends TestCase
             });
 
         $this->assertTrue($passed);
+    }
+
+    public function testFiniteMysqlTimeoutSuccess(): void
+    {
+        $passed = false;
+
+        $proc = self::lockMysqlAsync('foo', 2);
+        sleep(1);
+
+        try {
+            DB::connection('mysql')
+                ->advisoryLocker()
+                ->forSession()
+                ->withLocking('foo', function () use (&$passed): void {
+                    $passed = true;
+                }, 3);
+
+            $this->assertSame(0, $proc->wait());
+            $this->assertTrue($passed);
+        } finally {
+            $proc->wait();
+        }
+    }
+
+    public function testFiniteMysqlTimeoutExceeded(): void
+    {
+        $proc = self::lockMysqlAsync('foo', 3);
+        sleep(1);
+
+        try {
+            $this->expectException(LockFailedException::class);
+            $this->expectExceptionMessage('Failed to acquire lock: foo');
+
+            DB::connection('mysql')
+                ->advisoryLocker()
+                ->forSession()
+                ->withLocking('foo', function (): void {
+                }, 1);
+        } finally {
+            $proc->wait();
+        }
+    }
+
+    public function testInfiniteMysqlTimeoutSuccess(): void
+    {
+        $passed = false;
+
+        $proc = self::lockMysqlAsync('foo', 2);
+        sleep(1);
+
+        try {
+            DB::connection('mysql')
+                ->advisoryLocker()
+                ->forSession()
+                ->withLocking('foo', function () use (&$passed): void {
+                    $passed = true;
+                }, -1);
+
+            $this->assertSame(0, $proc->wait());
+            $this->assertTrue($passed);
+        } finally {
+            $proc->wait();
+        }
+    }
+
+    public function testFinitePostgresTimeoutInvalid(): void
+    {
+        $this->expectException(UnsupportedDriverException::class);
+        $this->expectExceptionMessage('Positive timeout is not supported');
+
+        DB::connection('pgsql')
+            ->advisoryLocker()
+            ->forSession()
+            ->withLocking('foo', function (): void {
+            }, 1);
+    }
+
+    public function testInfinitePostgresTimeoutSuccess(): void
+    {
+        $passed = false;
+
+        $proc = self::lockPostgresAsync('foo', 2);
+        sleep(1);
+
+        try {
+            DB::connection('pgsql')
+                ->advisoryLocker()
+                ->forSession()
+                ->withLocking('foo', function () use (&$passed): void {
+                    $passed = true;
+                }, -1);
+
+            $this->assertSame(0, $proc->wait());
+            $this->assertTrue($passed);
+        } finally {
+            $proc->wait();
+        }
     }
 }

--- a/tests/TransactionErrorRecoveryTest.php
+++ b/tests/TransactionErrorRecoveryTest.php
@@ -142,10 +142,14 @@ class TransactionErrorRecoveryTest extends TableTestCase
         } catch (QueryException $e) {
             // Thrown from [*]
             $this->assertSame(
-                $e->getMessage(),
                 'SQLSTATE[25P02]: In failed sql transaction: 7 ERROR:  '
                 . 'current transaction is aborted, commands ignored until end of transaction block '
-                . '(SQL: insert into users(id) values(2))',
+                . (
+                    version_compare($this->app->version(), '10.x-dev', '>=')
+                        ? '(Connection: pgsql, SQL: insert into users(id) values(2))'
+                        : '(SQL: insert into users(id) values(2))'
+                ),
+                $e->getMessage(),
             );
         }
 

--- a/tests/TransactionErrorRefreshDatabaseRecoveryTest.php
+++ b/tests/TransactionErrorRefreshDatabaseRecoveryTest.php
@@ -46,10 +46,14 @@ class TransactionErrorRefreshDatabaseRecoveryTest extends TestCase
         } catch (QueryException $e) {
             // Thrown from [*]
             $this->assertSame(
-                $e->getMessage(),
                 'SQLSTATE[25P02]: In failed sql transaction: 7 ERROR:  '
                 . 'current transaction is aborted, commands ignored until end of transaction block '
-                . '(SQL: insert into users(id) values(2))',
+                . (
+                    version_compare($this->app->version(), '10.x-dev', '>=')
+                        ? '(Connection: pgsql, SQL: insert into users(id) values(2))'
+                        : '(SQL: insert into users(id) values(2))'
+                ),
+                $e->getMessage(),
             );
         }
 
@@ -155,10 +159,14 @@ class TransactionErrorRefreshDatabaseRecoveryTest extends TestCase
         } catch (QueryException $e) {
             // Thrown from [*]
             $this->assertSame(
-                $e->getMessage(),
                 'SQLSTATE[25P02]: In failed sql transaction: 7 ERROR:  '
                 . 'current transaction is aborted, commands ignored until end of transaction block '
-                . '(SQL: insert into users(id) values(2))',
+                . (
+                    version_compare($this->app->version(), '10.x-dev', '>=')
+                        ? '(Connection: pgsql, SQL: insert into users(id) values(2))'
+                        : '(SQL: insert into users(id) values(2))'
+                ),
+                $e->getMessage(),
             );
         }
 


### PR DESCRIPTION
## Change MySQL function `LENGTH()` into `CHAR_LENGTH()`

Up to previous versions, MySQL lock keys were calculated by `LENGTH()` as a number of bytes in length. Actually, they should have been computed as multibyte strings by `CHAR_LENGTH()`.

## Allow `-1` (infinite wait) for Postgres timeout

Until previous versions, Postgres could not handle negative timeout seconds. With this change, it is now possible to wait infinitely. Note that it is still not possible to wait with a certain time limit.

## Follow Laravel 10 breaking changes

Starting with Laravel 10, the following pull request changes the constructor signature of `LockFailedException`.

- https://github.com/laravel/framework/pull/43190