### PR TITLE
fix: ci failure on testbench 9.x-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
           - { php: 8.0, lib: { laravel: ^11.0 } }
           - { php: 8.1, lib: { laravel: ^11.0 } }
         include:
-          - { lib: { laravel: ^9.0 }, phpstan: 1 }
-          - { lib: { laravel: ^10.0 }, phpstan: 1 }
+          - { lib: { laravel: ^9.0 }, stable: 1 }
+          - { lib: { laravel: ^10.0 }, stable: 1 }
 
     steps:
       - uses: actions/checkout@v3
@@ -74,8 +74,8 @@ jobs:
           coverage: xdebug
 
       - name: Remove impossible dependencies
-        if: ${{ matrix.phpstan != 1 }}
-        run: composer remove nunomaduro/larastan --dev --no-update
+        if: ${{ matrix.stable != 1 }}
+        run: composer remove nunomaduro/larastan friendsofphp/php-cs-fixer --dev --no-update
 
       - name: Adjust Package Versions
         run: |
@@ -86,10 +86,11 @@ jobs:
         run: mkdir -p build/logs
 
       - name: PHP-CS-Fixer
+        if: ${{ matrix.stable == 1 }}
         run: composer cs
 
       - name: PHPStan
-        if: ${{ matrix.phpstan == 1 }}
+        if: ${{ matrix.stable == 1 }}
         run: composer phpstan
 
       - name: Test


### PR DESCRIPTION
Hi! Are you eating vegetables?

1. Laravel11 requires `orchestra/testbench@9.x-dev`. The version of `symfony/process` that this version depends on is fixed to `7` .  
  https://github.com/orchestral/testbench/commit/c2bbe495f2ebd97e6e0cc3930017d07a2c8ee9ba
2. friendsofphp/php-cs-fixer requires `symfony/process@6`, so it cannot coexist with `orchestra/testbench@9.x-dev`, which requires `7`.  
  https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.37.1/composer.json#L37
3. But composer.json explicitly requires Laravel 11  
  https://github.com/mpyw/laravel-database-advisory-lock/blob/v4.3.0/.github/workflows/ci.yml#L82

Fixed that dependency resolution could not be performed due to the above conflict.

Since PHPStan is not running in Laravel 11, php-cs-fixer is also considered to be of low importance and is skipped.

Best WIP.